### PR TITLE
Render ants with role-specific colors

### DIFF
--- a/src/render/pixiRenderer.ts
+++ b/src/render/pixiRenderer.ts
@@ -1,6 +1,6 @@
 import { Application, Graphics, Sprite, Texture } from "pixi.js";
 import { Simulation } from "../sim/simulation";
-import { Cell } from "../sim/types";
+import { Cell, Role } from "../sim/types";
 
 export class PixiRenderer {
   app: Application;
@@ -119,20 +119,20 @@ export class PixiRenderer {
     // ants
     this.antGfx.clear();
     const s = this.sim.cfg.cellSize;
-    // Workers (white), Soldier (cyan), Queen (yellow)
     for (const a of this.sim.ants) {
       if (!a.alive) continue;
-      let color = 0xffffff;
-      // simple role color coding based on enum order
-      // 0=queen,1=worker,2=soldier
-      // (we could import Role to switch; keeping lightweight)
-      // queen yellow, worker white, soldier cyan
+      let color = 0xffffff; // default worker
+      switch (a.role) {
+        case Role.QUEEN:
+          color = 0xffff00; // yellow
+          break;
+        case Role.SOLDIER:
+          color = 0x00ffff; // cyan
+          break;
+      }
+      this.antGfx.beginFill(color, 0.95);
+      this.antGfx.drawRect(a.p.x * s, a.p.y * s, 1, 1);
+      this.antGfx.endFill();
     }
-    this.antGfx.beginFill(0xffffff, 0.95);
-    for (const a of this.sim.ants) {
-      if (!a.alive) continue;
-      this.antGfx.drawRect(a.p.x*s, a.p.y*s, 1, 1);
-    }
-    this.antGfx.endFill();
   }
 }


### PR DESCRIPTION
## Summary
- Color ants by role in Pixi renderer for better visual distinction between workers, soldiers, and the queen.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Top-level await not available in target environment)*
- `npm run headless`

------
https://chatgpt.com/codex/tasks/task_e_68ab37ba7bac8330908d4abfc9383376