### PR TITLE
Improve ant burrowing and role visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const sim = new Simulation({
   senseDist: 6,
   turnRate: 0.25,
   moveSpeed: 0.6,
-  nest: { x: 128, y: 1 },
+  nest: { x: 128, y: 11 },
   rngSeed: "demo",
   grassHeight: 12,
   energyDrain: 0.0012,

--- a/src/render/pixiRenderer.ts
+++ b/src/render/pixiRenderer.ts
@@ -131,21 +131,21 @@ export class PixiRenderer {
       this.antGfx.fill({ color: 0xff3b30, alpha: 0.95 });
     }
 
-    // workers — white
+    // workers — blue
     this.antGfx.beginPath();
     for (const a of this.sim.ants) {
       if (!a.alive || a.role !== Role.WORKER) continue;
       this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 2);
     }
-    this.antGfx.fill({ color: 0xffffff, alpha: 0.95 });
+    this.antGfx.fill({ color: 0x0000ff, alpha: 0.95 });
 
-    // soldiers — cyan
+    // soldiers — red
     this.antGfx.beginPath();
     for (const a of this.sim.ants) {
       if (!a.alive || a.role !== Role.SOLDIER) continue;
       this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 2);
     }
-    this.antGfx.fill({ color: 0x00ffff, alpha: 0.95 });
+    this.antGfx.fill({ color: 0xff0000, alpha: 0.95 });
 
     // queen — yellow (slightly larger)
     this.antGfx.beginPath();
@@ -153,7 +153,7 @@ export class PixiRenderer {
       if (!a.alive || a.role !== Role.QUEEN) continue;
       this.antGfx.rect(a.p.x * s, a.p.y * s, 2, 2);
     }
-    this.antGfx.fill({ color: 0xffee58, alpha: 1.0 });
+    this.antGfx.fill({ color: 0xffff00, alpha: 1.0 });
     
   }
 }

--- a/src/sim/ant.ts
+++ b/src/sim/ant.ts
@@ -1,4 +1,4 @@
-import { Ant, Role, WorldConfig, Enemy } from "./types";
+import { Ant, Role, WorldConfig, Enemy, Cell } from "./types";
 import { World } from "./world";
 
 export function makeQueen(spawn:{x:number;y:number}): Ant {
@@ -31,10 +31,11 @@ function turnToward(a: Ant, left:number, ahead:number, right:number, maxTurn:num
 function tryMoveOrDig(a:Ant, world:World, cfg:WorldConfig, nx:number, ny:number){
   const bx = Math.max(0, Math.min(world.cfg.width-1, nx));
   const by = Math.max(0, Math.min(world.cfg.height-1, ny));
+  const tile = world.tileAt(bx|0, by|0);
   const walkable = world.isWalkable(bx|0, by|0);
   if (walkable) {
     a.p.x = bx; a.p.y = by;
-  } else {
+  } else if (tile === Cell.DIRT || tile === Cell.GRASS) {
     if (a.role !== Role.SOLDIER) {
       world.dig(bx|0, by|0);
       a.energy -= cfg.digCost;
@@ -42,6 +43,8 @@ function tryMoveOrDig(a:Ant, world:World, cfg:WorldConfig, nx:number, ny:number)
     } else {
       a.a += (Math.random()-0.5)*Math.PI;
     }
+  } else {
+    a.a += (Math.random()-0.5)*Math.PI;
   }
 }
 

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -23,7 +23,10 @@ export class World {
   setTile(x:number,y:number,v:Cell){ this.tiles[this.idx(x|0,y|0)] = v; }
 
   isWalkable(x:number,y:number){
-    return this.tileAt(x,y) === Cell.AIR;
+    if (this.tileAt(x,y) !== Cell.AIR) return false;
+    // prevent ants from wandering into the sky; only allow the surface row
+    if (y < this.cfg.grassHeight - 1) return false;
+    return true;
   }
 
   generateTerrain(){


### PR DESCRIPTION
## Summary
- Prevent ants from roaming in the sky by limiting walkable cells
- Only dig dirt/grass cells and bounce off non-diggable tiles
- Color ants by caste (blue workers, red soldiers, yellow queen)
- Start nest on surface and ignore build artifacts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4368221083308c577ff84068ac39