### PR TITLE
Refactor ant habitat and rendering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,14 +53,14 @@ async function boot() {
   }
   requestAnimationFrame(loop);
 
-  // add food on canvas clicks
+  // spawn single food pixel on click
   const canvas = renderer.app.canvas as HTMLCanvasElement;
   canvas.addEventListener("pointerdown", (e) => {
     const rect = canvas.getBoundingClientRect();
     const x = Math.floor((e.clientX - rect.left) / sim.cfg.cellSize);
     const y = Math.floor((e.clientY - rect.top) / sim.cfg.cellSize);
     if (x >= 0 && y >= 0 && x < sim.cfg.width && y < sim.cfg.height) {
-      sim.world.addFoodCircle(x, y, 6, 10);
+      sim.world.addFood(x, y, 10);
     }
   });
 }

--- a/src/render/pixiRenderer.ts
+++ b/src/render/pixiRenderer.ts
@@ -69,6 +69,7 @@ export class PixiRenderer {
     const w = this.sim.world.cfg.width;
     const h = this.sim.world.cfg.height;
     const tiles = this.sim.world.tiles;
+    const food = this.sim.world.food;
 
     const img = this.terrainCtx.createImageData(w, h);
     const data = img.data;
@@ -81,7 +82,9 @@ export class PixiRenderer {
       const t = tiles[i];
       const idx = i*4;
       let c;
-      if (t === Cell.DIRT) c = soil;
+      if (food[i] > 0) {
+        c = [0, 255, 0];
+      } else if (t === Cell.DIRT) c = soil;
       else if (t === Cell.GRASS) c = grass;
       else c = air;
       data[idx] = c[0]; data[idx+1] = c[1]; data[idx+2] = c[2]; data[idx+3] = 255;
@@ -126,7 +129,7 @@ export class PixiRenderer {
       this.antGfx.beginPath();
       for (const e of simAny.enemies) {
         if (!e.alive) continue;
-        this.antGfx.rect(e.p.x * s, e.p.y * s, 1, 2);
+        this.antGfx.rect(e.p.x * s, e.p.y * s, 1, 1);
       }
       this.antGfx.fill({ color: 0xff3b30, alpha: 0.95 });
     }
@@ -135,7 +138,7 @@ export class PixiRenderer {
     this.antGfx.beginPath();
     for (const a of this.sim.ants) {
       if (!a.alive || a.role !== Role.WORKER) continue;
-      this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 2);
+      this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 1);
     }
     this.antGfx.fill({ color: 0x0000ff, alpha: 0.95 });
 
@@ -143,7 +146,7 @@ export class PixiRenderer {
     this.antGfx.beginPath();
     for (const a of this.sim.ants) {
       if (!a.alive || a.role !== Role.SOLDIER) continue;
-      this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 2);
+      this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 1);
     }
     this.antGfx.fill({ color: 0xff0000, alpha: 0.95 });
 
@@ -151,7 +154,7 @@ export class PixiRenderer {
     this.antGfx.beginPath();
     for (const a of this.sim.ants) {
       if (!a.alive || a.role !== Role.QUEEN) continue;
-      this.antGfx.rect(a.p.x * s, a.p.y * s, 2, 2);
+      this.antGfx.rect(a.p.x * s, a.p.y * s, 1, 1);
     }
     this.antGfx.fill({ color: 0xffff00, alpha: 1.0 });
     

--- a/src/sim/simulation.ts
+++ b/src/sim/simulation.ts
@@ -1,5 +1,5 @@
 import { World } from "./world";
-import { makeQueen, makeSoldier, makeWorkers, stepAnt } from "./ant";
+import { makeQueen, makeSoldier, makeWorker, stepAnt } from "./ant";
 import { WorldConfig, Ant, Enemy } from "./types";
 import { spawnEnemy, stepEnemy } from "./enemy";
 
@@ -13,8 +13,11 @@ export class Simulation {
     this.cfg = cfg;
     this.world = new World(cfg);
 
-    const spawn = { x: cfg.nest.x, y: Math.max(0, cfg.grassHeight - 1) };
-    this.ants = [ makeQueen(spawn), ...makeWorkers(cfg.ants, spawn) ];
+    const queenSpawn = { x: cfg.nest.x, y: 0 };
+    this.ants = [ makeQueen(queenSpawn) ];
+    for (let i=0; i<cfg.ants; i++) {
+      this.ants.push(makeWorker({ x: Math.random()*cfg.width, y: 0 }));
+    }
     this.enemies = [];
   }
 
@@ -30,8 +33,10 @@ export class Simulation {
       this.world.colonyFood -= this.cfg.spawnThreshold;
       const spawn = { x: this.cfg.nest.x, y: this.cfg.nest.y };
       if (Math.random() < this.cfg.soldierRatio) this.ants.push(makeSoldier(spawn));
-      else this.ants.push(...makeWorkers(1, spawn));
+      else this.ants.push(makeWorker(spawn));
     }
+
+    this.world.stepDirt();
     this.world.pher.step(this.cfg.evap, this.cfg.diffuse);
   }
 }

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -47,6 +47,10 @@ export class World {
       const dx=x-cx, dy=y-cy; if(dx*dx+dy*dy<=r*r) this.food[this.idx(x,y)] += amt;
     }
   }
+
+  addFood(x:number,y:number,amt:number){
+    if (this.inBounds(x,y)) this.food[this.idx(x,y)] += amt;
+  }
   takeFood(x:number,y:number, amt:number){
     const i = this.idx(x|0,y|0);
     const t = Math.min(this.food[i], amt);
@@ -56,5 +60,19 @@ export class World {
   dig(x:number,y:number){
     const t = this.tileAt(x,y);
     if (t === Cell.DIRT || t === Cell.GRASS) this.setTile(x,y, Cell.AIR);
+  }
+
+  stepDirt(){
+    const { width, height } = this.cfg;
+    for (let y=height-2; y>=0; y--){
+      for (let x=0; x<width; x++){
+        const i = this.idx(x,y);
+        const below = this.idx(x,y+1);
+        if (this.tiles[i] === Cell.DIRT && this.tiles[below] === Cell.AIR){
+          this.tiles[below] = Cell.DIRT;
+          this.tiles[i] = Cell.AIR;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Animate falling dirt to reveal tunnels as ants dig
- Spawn ants from the top and let them drop to the surface
- Render ants as single pixels and allow placing single food pixels

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a50f9508330baec9bbf22a3d703