### PR TITLE
Deterministic ant behaviour with seeded trails and optional tiles

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -12,6 +12,7 @@ const sim = new Simulation({
   turnRate: 0.25,
   moveSpeed: 0.6,
   nest: { x: 64, y: 1 },
+  rngSeed: "headless",
   grassHeight: 8,
   energyDrain: 0.001,
   digCost: 0.002,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,69 +1,46 @@
-// (imports at the top)
 import { Simulation } from "./sim/simulation";
 import { PixiRenderer } from "./render/pixiRenderer";
 
-// ---- config (top)
 const sim = new Simulation({
   width: 256, height: 256, cellSize: 3,
   ants: 300,
-  evap: 0.01,
-  diffuse: 0.05,
-  depositFood: 0.03,
-  depositHome: 0.02,
-  senseAngle: Math.PI / 6,
-  senseDist: 6,
-  turnRate: 0.25,
-  moveSpeed: 0.6,
-  nest: { x: 128, y: 11 },
-  rngSeed: "demo",
-  grassHeight: 12,
-  energyDrain: 0.0012,
-  digCost: 0.0020,
-  spawnThreshold: 8,
-  soldierRatio: 0.2,
+  evap: 0.01, diffuse: 0.05,
+  depositFood: 0.03, depositHome: 0.02,
+  senseAngle: Math.PI/6, senseDist: 6,
+  turnRate: 0.25, moveSpeed: 0.6,
+  nest: { x: 128, y: 1 },
+  rngSeed: new URLSearchParams(location.search).get("seed") ?? "demo",
+  grassHeight: 12, energyDrain: 0.0012, digCost: 0.0020,
+  spawnThreshold: 8, soldierRatio: 0.2,
+  // homes: [{x:80,y:11},{x:176,y:11}], // optional multi-home
 });
 
-// seed food on surface
-sim.world.addFoodCircle(60,  sim.world.cfg.grassHeight - 1, 5, 12);
-sim.world.addFoodCircle(200, sim.world.cfg.grassHeight - 1, 5, 12);
+sim.world.addFoodCircle(60,  sim.world.cfg.grassHeight-1, 5, 12);
+sim.world.addFoodCircle(200, sim.world.cfg.grassHeight-1, 5, 12);
 
-const renderer = new PixiRenderer(
-  sim,
-  sim.cfg.width * sim.cfg.cellSize,
-  sim.cfg.height * sim.cfg.cellSize
-);
+const renderer = new PixiRenderer(sim, sim.cfg.width*sim.cfg.cellSize, sim.cfg.height*sim.cfg.cellSize);
 
-// ---- boot (mid-file)
 async function boot() {
   await renderer.init();
 
   const hudAntCount = document.getElementById("antCount");
-
-  let last = performance.now();
-  let acc = 0;
-  const dt = 1000 / 60;
+  let last = performance.now(), acc = 0;
+  const dt = 1000/60;
 
   function loop(now: number) {
     acc += now - last; last = now;
     while (acc >= dt) { sim.step(); acc -= dt; }
     renderer.draw();
-    // live count of alive ants
-    if (hudAntCount) hudAntCount.textContent = String(sim.ants.filter(a => a.alive).length);
+    if (hudAntCount) hudAntCount.textContent = String(sim.ants.filter(a=>a.alive).length);
     requestAnimationFrame(loop);
   }
   requestAnimationFrame(loop);
 
-  // spawn single food pixel on click
-  const canvas = renderer.app.canvas as HTMLCanvasElement;
-  canvas.addEventListener("pointerdown", (e) => {
-    const rect = canvas.getBoundingClientRect();
-    const x = Math.floor((e.clientX - rect.left) / sim.cfg.cellSize);
-    const y = Math.floor((e.clientY - rect.top) / sim.cfg.cellSize);
-    if (x >= 0 && y >= 0 && x < sim.cfg.width && y < sim.cfg.height) {
-      sim.world.addFood(x, y, 10);
-    }
+  (renderer.app.canvas as HTMLCanvasElement).addEventListener("pointerdown", (e)=>{
+    const rect = (renderer.app.canvas as HTMLCanvasElement).getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left)/sim.cfg.cellSize);
+    const y = Math.floor((e.clientY - rect.top)/sim.cfg.cellSize);
+    if (x>=0 && y>=0 && x<sim.cfg.width && y<sim.cfg.height) sim.world.addFoodCircle(x,y,6,10);
   });
 }
-
-// ---- call boot (bottom)
 boot();

--- a/src/render/pixiRenderer.ts
+++ b/src/render/pixiRenderer.ts
@@ -18,6 +18,8 @@ export class PixiRenderer {
   private terrainTex!: Texture;
   private terrainSprite!: Sprite;
 
+  private tileTex: { sky?: Texture; grass?: Texture; dirt?: Texture; tunnel?: Texture } = {};
+
   private widthPx: number;
   private heightPx: number;
   private _ready = false;
@@ -59,6 +61,13 @@ export class PixiRenderer {
     this.terrainSprite = new Sprite(this.terrainTex);
     this.terrainSprite.scale.set(this.sim.cfg.cellSize);
 
+    try {
+      this.tileTex.sky    = await Texture.fromURL("/tiles/sky.png");
+      this.tileTex.grass  = await Texture.fromURL("/tiles/grass.png");
+      this.tileTex.dirt   = await Texture.fromURL("/tiles/dirt.png");
+      this.tileTex.tunnel = await Texture.fromURL("/tiles/tunnel.png");
+    } catch {}
+
     this.app.stage.addChildAt(this.terrainSprite, 0);
     this.app.stage.addChildAt(this.pherSprite, 1);
 
@@ -71,9 +80,32 @@ export class PixiRenderer {
     const tiles = this.sim.world.tiles;
     const food = this.sim.world.food;
 
+    if (this.tileTex.dirt) {
+      const ctx = this.terrainCtx;
+      ctx.clearRect(0,0,w,h);
+      for (let y=0;y<h;y++){
+        for (let x=0;x<w;x++){
+          const idx = y*w + x;
+          if (food[idx] > 0) {
+            ctx.fillStyle = "#00ff00";
+            ctx.fillRect(x, y, 1, 1);
+            continue;
+          }
+          const t = tiles[idx];
+          let tex: Texture | undefined;
+          if (t === Cell.DIRT) tex = this.tileTex.dirt;
+          else if (t === Cell.GRASS) tex = this.tileTex.grass;
+          else tex = y < this.sim.world.cfg.grassHeight ? this.tileTex.sky : this.tileTex.tunnel;
+          const img = (tex as any)?.source?.resource;
+          if (img) ctx.drawImage(img, x, y, 1, 1);
+        }
+      }
+      this.terrainTex.update();
+      return;
+    }
+
     const img = this.terrainCtx.createImageData(w, h);
     const data = img.data;
-
     const soil = [145, 102, 19];
     const grass = [34, 139, 34];
     const air = [11, 13, 16];

--- a/src/sim/enemy.ts
+++ b/src/sim/enemy.ts
@@ -1,14 +1,19 @@
 import { Enemy, WorldConfig } from "./types";
 import { World } from "./world";
 
+function rand(world: World){
+  const rng = (world as any).sim?.rng;
+  return rng ? rng.next() : Math.random();
+}
+
 export function spawnEnemy(world: World, cfg: WorldConfig): Enemy {
-  const x = Math.max(0, Math.min(cfg.width - 1, cfg.nest.x + (Math.random() * 40 - 20)));
+  const x = Math.max(0, Math.min(cfg.width - 1, cfg.nest.x + (rand(world) * 40 - 20)));
   const y = cfg.grassHeight - 1;
-  return { p: { x, y }, a: Math.random() * Math.PI * 2, alive: true };
+  return { p: { x, y }, a: rand(world) * Math.PI * 2, alive: true };
 }
 
 export function stepEnemy(e: Enemy, world: World, cfg: WorldConfig) {
-  e.a += (Math.random() - 0.5) * 0.3;
+  e.a += (rand(world) - 0.5) * 0.3;
   const nx = e.p.x + Math.cos(e.a) * 0.4;
   const ny = e.p.y + Math.sin(e.a) * 0.4;
   e.p.x = Math.max(0, Math.min(cfg.width - 1, nx));

--- a/src/sim/rng.ts
+++ b/src/sim/rng.ts
@@ -1,0 +1,22 @@
+export class RNG {
+  private s = 0;
+  constructor(seed: number | string) {
+    this.s = typeof seed === "number" ? seed|0 : hashString(seed);
+    if (this.s === 0) this.s = 0x9e3779b9;
+  }
+  next() {
+    let t = this.s += 0x6D2B79F5;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+  range(a=0, b=1) { return a + (b - a) * this.next(); }
+  int(max: number) { return (this.next() * max) | 0; }
+}
+export function hashString(str: string){
+  let h1=0xdeadbeef, h2=0x41c6ce57;
+  for (let i=0;i<str.length;i++){ const ch=str.charCodeAt(i); h1=Math.imul(h1^ch,2654435761); h2=Math.imul(h2^ch,1597334677); }
+  h1 = Math.imul(h1 ^ (h1>>>16), 2246822507) ^ Math.imul(h2 ^ (h2>>>13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2>>>16), 2246822507) ^ Math.imul(h1 ^ (h1>>>13), 3266489909);
+  return (h2>>>0);
+}

--- a/src/sim/simulation.ts
+++ b/src/sim/simulation.ts
@@ -1,39 +1,49 @@
 import { World } from "./world";
 import { makeQueen, makeSoldier, makeWorker, stepAnt } from "./ant";
-import { WorldConfig, Ant, Enemy } from "./types";
+import { WorldConfig, Ant, Enemy, Vec2 } from "./types";
 import { spawnEnemy, stepEnemy } from "./enemy";
+import { RNG } from "./rng";
 
 export class Simulation {
   world: World;
   ants: Ant[];
   cfg: WorldConfig;
   enemies: Enemy[];
+  rng: RNG;
+  homes: Vec2[];
 
   constructor(cfg: WorldConfig) {
+    const urlSeed = new URLSearchParams(globalThis.location?.search ?? "").get("seed") ?? cfg.rngSeed ?? "demo";
+    this.rng = new RNG(urlSeed);
     this.cfg = cfg;
+    (this.cfg as any).rng = this.rng;
+
+    this.homes = cfg.homes?.length ? cfg.homes.slice() : [cfg.nest];
+
     this.world = new World(cfg);
+    (this.world as any).sim = this;
 
     const queenSpawn = { x: cfg.nest.x, y: 0 };
     this.ants = [ makeQueen(queenSpawn) ];
     for (let i=0; i<cfg.ants; i++) {
-      this.ants.push(makeWorker({ x: Math.random()*cfg.width, y: 0 }));
+      this.ants.push(makeWorker({ x: this.rng.next()*cfg.width, y: 0 }, this.rng.next()*Math.PI*2));
     }
     this.enemies = [];
   }
 
   step() {
     for (const ant of this.ants) stepAnt(ant, this.world, this.cfg, this.enemies);
-    if ((Math.random()*60|0)===0) this.ants = this.ants.filter(a=>a.alive);
+    if ((this.rng.int(60))===0) this.ants = this.ants.filter(a=>a.alive);
 
     for (const enemy of this.enemies) stepEnemy(enemy, this.world, this.cfg);
     this.enemies = this.enemies.filter(e=>e.alive);
-    if (Math.random() < 0.005) this.enemies.push(spawnEnemy(this.world, this.cfg));
+    if (this.rng.next() < 0.005) this.enemies.push(spawnEnemy(this.world, this.cfg));
 
     if (this.world.colonyFood >= this.cfg.spawnThreshold) {
       this.world.colonyFood -= this.cfg.spawnThreshold;
       const spawn = { x: this.cfg.nest.x, y: this.cfg.nest.y };
-      if (Math.random() < this.cfg.soldierRatio) this.ants.push(makeSoldier(spawn));
-      else this.ants.push(makeWorker(spawn));
+      if (this.rng.next() < this.cfg.soldierRatio) this.ants.push(makeSoldier(spawn, this.rng.next()*Math.PI*2));
+      else this.ants.push(makeWorker(spawn, this.rng.next()*Math.PI*2));
     }
 
     this.world.stepDirt();

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -42,6 +42,7 @@ export interface WorldConfig {
   turnRate: number;
   moveSpeed: number;
   rngSeed?: string;
+  homes?: Vec2[];
   nest: Vec2;                      // initial (surface), queen will move
   grassHeight: number;             // sky thickness before grass row
   energyDrain: number;             // per-step


### PR DESCRIPTION
## Summary
- Add seeded RNG utility and propagate it through simulation for deterministic runs and reproducible replays
- Rework worker behaviour to follow/delay pheromone trails with falloff, steering and multi-home support
- Load optional terrain tile textures and parse URL seed in main entry

## Testing
- `npm run build`
- `npm run headless`


------
https://chatgpt.com/codex/tasks/task_e_68ab571ff9fc8330b584ae4a0d0337ca