### PR TITLE
Use black canvas with gray dirt

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Ant Simulator (TS + PixiJS)</title>
     <style>
       :root { color-scheme: dark; }
-      html, body { height: 100%; margin: 0; background: #0b0d10; }
+      html, body { height: 100%; margin: 0; background: #000000; }
       #app { height: 100%; display: grid; place-items: center; }
       canvas { image-rendering: pixelated; border-radius: 14px; box-shadow: 0 12px 36px rgba(0,0,0,.45); }
       #hud {


### PR DESCRIPTION
## Summary
- Render terrain with simple black background and gray dirt
- Remove unused tile textures and background page color to black

## Testing
- `npm run build`
- `npm run headless`


------
https://chatgpt.com/codex/tasks/task_e_68ab58c43d5c83308b251994d56a3692