### PR TITLE
Track dug habitat in ant simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm run build && npm run preview
 npm run headless
 ```
 
-Open the browser dev server (Vite will open for you) and click anywhere on the canvas to add food. The HUD shows the current ant count and a hint.
+Open the browser dev server (Vite will open for you) and click anywhere on the canvas to add food. The HUD shows the current ant count, the size of the dug habitat, and a hint.
 
 ## Project structure
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <div id="hud">Click to add food • <b id="antCount">–</b> ants<br><small>Pheromones: RED-SOLDIERS - YELLOW-QUEEN - BLUE-WORKER - GREEN-FOOD</small></div>
+    <div id="hud">Click to add food • <b id="antCount">–</b> ants • <b id="habitatSize">0</b> habitat cells<br><small>Pheromones: RED-SOLDIERS - YELLOW-QUEEN - BLUE-WORKER - GREEN-FOOD</small></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -28,7 +28,7 @@ for (let i=0;i<1500;i++) {
   if ((i%200)===0) {
     const totalFood = sim.world.pher.food.reduce((a,b)=>a+b,0);
     const totalHome = sim.world.pher.home.reduce((a,b)=>a+b,0);
-    console.log(`step=${i} ants=${sim.ants.length} colonyFood=${sim.world.colonyFood.toFixed(1)} pher(food=${totalFood.toFixed(1)}, home=${totalHome.toFixed(1)})`);
+    console.log(`step=${i} ants=${sim.ants.length} colonyFood=${sim.world.colonyFood.toFixed(1)} habitat=${sim.world.habitatCells} pher(food=${totalFood.toFixed(1)}, home=${totalHome.toFixed(1)})`);
   }
 }
 console.log("Done.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ async function boot() {
   await renderer.init();
 
   const hudAntCount = document.getElementById("antCount");
+  const hudHabitat = document.getElementById("habitatSize");
   let last = performance.now(), acc = 0;
   const dt = 1000/60;
 
@@ -32,6 +33,7 @@ async function boot() {
     while (acc >= dt) { sim.step(); acc -= dt; }
     renderer.draw();
     if (hudAntCount) hudAntCount.textContent = String(sim.ants.filter(a=>a.alive).length);
+    if (hudHabitat) hudHabitat.textContent = String(sim.world.habitatCells);
     requestAnimationFrame(loop);
   }
   requestAnimationFrame(loop);

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -7,6 +7,7 @@ export class World {
   food: Float32Array;
   tiles: Uint8Array;
   colonyFood = 0;
+  habitatCells = 0; // number of dug-out cells forming the colony's habitat
 
   constructor(cfg: WorldConfig) {
     this.cfg = cfg;
@@ -59,11 +60,14 @@ export class World {
 
   dig(x:number,y:number){
     const t = this.tileAt(x,y);
-    if (t === Cell.DIRT || t === Cell.GRASS) this.setTile(x,y, Cell.AIR);
+    if (t === Cell.DIRT || t === Cell.GRASS) {
+      this.setTile(x,y, Cell.AIR);
+      if (y >= this.cfg.grassHeight) this.habitatCells++;
+    }
   }
 
   stepDirt(){
-    const { width, height } = this.cfg;
+    const { width, height, grassHeight } = this.cfg;
     for (let y=height-2; y>=0; y--){
       for (let x=0; x<width; x++){
         const i = this.idx(x,y);
@@ -71,6 +75,8 @@ export class World {
         if (this.tiles[i] === Cell.DIRT && this.tiles[below] === Cell.AIR){
           this.tiles[below] = Cell.DIRT;
           this.tiles[i] = Cell.AIR;
+          if (y+1 >= grassHeight) this.habitatCells--; // dirt fell into a tunnel
+          if (y   >= grassHeight) this.habitatCells++; // new air left behind
         }
       }
     }


### PR DESCRIPTION
## Summary
- Track number of tunnel cells dug out by ants and adjust when dirt collapses
- Expose habitat size in HUD and headless logs
- Document habitat tracking in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run headless`


------
https://chatgpt.com/codex/tasks/task_e_68ab590b64708330ab647b1509a3277c